### PR TITLE
remove deprecated c++ option.

### DIFF
--- a/GBRLikelihood/BuildFile.xml
+++ b/GBRLikelihood/BuildFile.xml
@@ -1,5 +1,5 @@
 
-<flags CXXFLAGS="-O3 -ftree-loop-linear -floop-interchange -ffast-math -fopenmp -std=gnu++1y"/>
+<flags CXXFLAGS="-O3 -ftree-loop-linear -floop-interchange -ffast-math -fopenmp"/>
 <use name="root"/>
 <use name="rootgraphics"/>
 <use name="rootmath"/>


### PR DESCRIPTION
Need this modification in order to make this package compile under CMSSW_10_5, 10_6, etc.
Need more work in order to make it compatible with CMSSW_11, 12, 13, etc.
